### PR TITLE
Hotfix app id creation

### DIFF
--- a/hamper/helpers/driver.py
+++ b/hamper/helpers/driver.py
@@ -6,7 +6,7 @@
 # which makes it a pain to have multiple browser windows handle the process)
 #
 
-from selenium.webdriver.chrome.webdriver import WebDriver as PhantomJS
+from selenium.webdriver.phantomjs.webdriver import WebDriver as PhantomJS
 
 import singleton
 


### PR DESCRIPTION
I noticed this issue for the first time when Hamper was running in our production environment.

The script was throwing an error/exception when trying to create an app ID. The reason for this was because identifier.py was diagnosing an error if the page didn't move onto a page with "formID=1469461" in the URL.

The script now stores the page URL before the button click, clicks the button, waits for the page to move, checks the new URL against the saved URL. If they are the same, we scan for an error. If they are not we can assume that the page has forwarded onto the confirmation screen.
